### PR TITLE
fix typo, add navbar links

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,9 @@
             <div id="navbar" class="navbar-collapse collapse">
               <ul class="nav navbar-nav">
                 <li class="active"><a href="#">Home</a></li>
-                <li><a href="#about">About</a></li>
-                <li><a href="#contact">Contact</a></li>
+                <li><a href="#6th">6th Grade</a></li>
+                <li><a href="#7th">7th Grade</a></li>
+                <li><a href="#8th">8th Grade</a></li>
               </ul>
             </div>
           </div>
@@ -70,7 +71,7 @@
           <div class="container">
             <div id="header" class="carousel-caption">
               <h1 class="blacktext">Hi!</h1>
-              <p class="blacktext">This is my portfolio showcasing my best works so far as a student in MME.<br><br><br></p>
+              <p class="blacktext">This is my portfolio showcasing my best work so far as a student at MME.<br><br><br></p>
               <p><a class="btn btn-lg btn-primary" href="#" role="button">See More</a></p>
             </div>
           </div>
@@ -108,7 +109,7 @@
 
       <div class="row featurette">
         <div class="col-md-7">
-          <h2 class="featurette-heading">6th Grade: <span class="text-muted">A New School</span></h2>
+          <h2 class="featurette-heading" id="6th">6th Grade: <span class="text-muted">A New School</span></h2>
           <p class="lead">New teachers, new assignments, new schedule, new homework, new everything.</p>
           <p><a class="btn btn-default" href="#" role="button">More &raquo;</a></p>
         </div>
@@ -121,7 +122,7 @@
 
       <div class="row featurette">
         <div class="col-md-7 col-md-push-5">
-          <h2 class="featurette-heading">7th Grade: <span class="text-muted">The Programming Strikes Back</span></h2>
+          <h2 class="featurette-heading" id="7th">7th Grade: <span class="text-muted">The Programming Strikes Back</span></h2>
           <p class="lead">The release of mPass, the height of <a href="https://mtkacodersunite.github.io">Coders Unite</a> and other enlightening things.</p>
           <p><a class="btn btn-default" href="#" role="button">More &raquo;</a></p>
         </div>
@@ -134,7 +135,7 @@
 
       <div class="row featurette">
         <div class="col-md-7">
-          <h2 class="featurette-heading">8th Grade: <span class="text-muted">Not yet</span></h2>
+          <h2 class="featurette-heading" id="8th">8th Grade: <span class="text-muted">Not yet</span></h2>
           <p class="lead">I am not in 8th grade yet. Soon to come....</p>
           <p><a class="btn btn-default" href="#" role="button">More &raquo;</a></p>
         </div>


### PR DESCRIPTION
Fix typo(s), add links to 6th, 7th, and 8th grade years on navbar that scroll to respective locations. 

Buttons saying `About` and `Contact` don't make sense in the context, so this commit changes that and makes it make a lot more sense. Also, the buttons work. 

Typo was where @eado wrote 

> showcasing my best `works`

and also when he wrote

> so far as a student `in` MME